### PR TITLE
core dumped with open3d 1.13.0

### DIFF
--- a/utils/core.py
+++ b/utils/core.py
@@ -7,7 +7,6 @@ import torch
 import voxelocc
 import voxelfeat
 import numpy as np
-import open3d as o3d
 import utils.config as cfg
 from utils.tools import imshow
 import utils.vox_utils.vox as vox

--- a/utils/point_clouds.py
+++ b/utils/point_clouds.py
@@ -3,9 +3,7 @@
 import copy
 import torch
 import random
-import pygicp
 import numpy as np
-import open3d as o3d
 import utils.config as cfg
 
 
@@ -56,6 +54,7 @@ def apply_transform(pc: torch.Tensor, m: torch.Tensor):
 
 # Make up feature with open3d
 def make_open3d_feature(data, dim, npts):
+    import open3d as o3d
     feature = o3d.pipelines.registration.Feature()
     feature.resize(dim, npts)
     feature.data = data.cpu().numpy().astype('d').transpose()
@@ -64,6 +63,7 @@ def make_open3d_feature(data, dim, npts):
 
 # Make up point cloud with open3d
 def make_open3d_point_cloud(xyz, color=None):
+    import open3d as o3d
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(xyz)
     if color is not None:
@@ -75,6 +75,7 @@ def draw_pc(pc):
     '''
     pc: np.ndarray
     '''
+    import open3d as o3d
     pc = copy.deepcopy(pc)
     pcd1 = o3d.geometry.PointCloud()
     pcd1.points = o3d.utility.Vector3dVector(pc)    
@@ -91,6 +92,7 @@ def draw_pc_pair(pc1, pc2):
     '''
     pc1 & pc2: np.ndarray
     '''    
+    import open3d as o3d
     pc1 = copy.deepcopy(pc1)
     pc2 = copy.deepcopy(pc2)    
     pcd1 = o3d.geometry.PointCloud()
@@ -111,6 +113,7 @@ def draw_registration_result(source, target, transformation):
     '''
     source & target: np.ndarray
     '''        
+    import open3d as o3d
     source = copy.deepcopy(source)
     target = copy.deepcopy(target)    
     pcd1 = o3d.geometry.PointCloud()
@@ -131,6 +134,7 @@ def draw_registration_result(source, target, transformation):
 # fast_gicp (https://github.com/SMRT-AIST/fast_gicp)
 def fast_gicp(source, target, max_correspondence_distance=1.0, init_pose=np.eye(4)):
     # downsample the point cloud before registration
+    import pygicp
     source = pygicp.downsample(source, 0.25)
     target = pygicp.downsample(target, 0.25)
 
@@ -158,6 +162,7 @@ def fast_gicp(source, target, max_correspondence_distance=1.0, init_pose=np.eye(
 def o3d_icp(source, target, transform: np.ndarray = None, point2plane: bool = False,
         inlier_dist_threshold: float = 1.0, max_iteration: int = 200):
     # transform: initial alignment transform
+    import open3d as o3d
     if transform is not None:
         transform = transform.astype(float)
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -7,7 +7,6 @@ import errno
 import torch
 import pickle
 import numpy as np
-import open3d as o3d
 import utils.config as cfg
 import matplotlib.pyplot as plt
 from scipy.spatial import distance_matrix


### PR DESCRIPTION
import both o3d and gicp may lead to link error and cause the segmentation fault.

reproducible in [lus6/ring:noetic](https://hub.docker.com/r/lus6/ring)
```python3
import numpy as np
import open3d as o3d
import pygicp

target = np.random.rand(5, 3)

gicp = pygicp.FastGICP()
gicp.set_input_target(target)
```
with backtrace
```sh
#0  0x00007f769c3ee623 in flann::anyimpl::small_any_policy<flann::flann_algorithm_t>::print(std::ostream&, void* const*) () from /usr/local/lib/python3.8/dist-packages/open3d/cpu/pybind.cpython-38-x86_64-linux-gnu.so
#1  0x00007f765dc2ca0d in flann::flann_algorithm_t flann::get_param<flann::flann_algorithm_t>(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, flann::any, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, flann::any> > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) () from /lib/x86_64-linux-gnu/libpcl_segmentation.so.1.10
#2  0x00007f765dcc7ba7 in flann::Index<flann::L2_Simple<float> >::Index(flann::Matrix<float> const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, flann::any, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, flann::any> > > const&, flann::L2_Simple<float>) ()
   from /lib/x86_64-linux-gnu/libpcl_segmentation.so.1.10
#3  0x00007f765dcc85de in pcl::KdTreeFLANN<pcl::PointXYZ, flann::L2_Simple<float> >::setInputCloud(boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> const&, boost::shared_ptr<std::vector<int, std::allocator<int> > const> const&)
    () from /lib/x86_64-linux-gnu/libpcl_segmentation.so.1.10
#4  0x00007f765dc9d4bf in pcl::search::KdTree<pcl::PointXYZ, pcl::KdTreeFLANN<pcl::PointXYZ, flann::L2_Simple<float> > >::setInputCloud(boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> const&, boost::shared_ptr<std::vector<int, std::allocator<int> > const> const&) () from /lib/x86_64-linux-gnu/libpcl_segmentation.so.1.10
#5  0x00007f765dfd42e2 in fast_gicp::FastGICP<pcl::PointXYZ, pcl::PointXYZ>::setInputTarget(boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> const&) () from /home/RING/utils/fast_gicp/build/lib.linux-x86_64-3.8/libfast_gicp.so
#6  0x00007f765e01272a in ?? () from /root/.local/lib/python3.8/site-packages/pygicp-0.0.1-py3.8-linux-x86_64.egg/pygicp.cpython-38-x86_64-linux-gnu.so
#7  0x00007f765e020ec6 in ?? () from /root/.local/lib/python3.8/site-packages/pygicp-0.0.1-py3.8-linux-x86_64.egg/pygicp.cpython-38-x86_64-linux-gnu.so
#8  0x00000000005d5499 in cfunction_call_varargs (kwargs=<optimized out>, args=<optimized out>, func=<built-in method set_input_target of PyCapsule object at remote 0x7f76d2cf0b70>) at ../Objects/call.c:773
#9  PyCFunction_Call (func=<built-in method set_input_target of PyCapsule object at remote 0x7f76d2cf0b70>, args=<optimized out>, kwargs=<optimized out>) at ../Objects/call.c:773
#10 0x00000000005d6066 in _PyObject_MakeTpCall (callable=<built-in method set_input_target of PyCapsule object at remote 0x7f76d2cf0b70>, args=<optimized out>, nargs=<optimized out>, keywords=<optimized out>)
    at ../Include/internal/pycore_pyerrors.h:13
#11 0x00000000004e22b3 in _PyObject_Vectorcall (kwnames=0x0, nargsf=<optimized out>, args=0x7f76d65887b0, callable=<built-in method set_input_target of PyCapsule object at remote 0x7f76d2cf0b70>) at ../Include/cpython/abstract.h:125
#12 _PyObject_Vectorcall (kwnames=0x0, nargsf=<optimized out>, args=0x7f76d65887b0, callable=<built-in method set_input_target of PyCapsule object at remote 0x7f76d2cf0b70>) at ../Include/cpython/abstract.h:115
#13 method_vectorcall (method=<optimized out>, args=0x7f76d65887b8, nargsf=<optimized out>, kwnames=0x0) at ../Objects/classobject.c:60
#14 0x000000000054c8a9 in _PyObject_Vectorcall (kwnames=0x0, nargsf=<optimized out>, args=0x7f76d65887b8, callable=<method at remote 0x7f76a35bc080>) at ../Include/cpython/abstract.h:127
#15 call_function (kwnames=0x0, oparg=<optimized out>, pp_stack=<synthetic pointer>, tstate=0xb2e970) at ../Python/ceval.c:4963
#16 _PyEval_EvalFrameDefault (f=<optimized out>, throwflag=<optimized out>) at ../Python/ceval.c:3469
#17 0x000000000054552a in PyEval_EvalFrameEx (throwflag=0, f=Frame 0x7f76d6588640, for file a.py, line 8, in <module> ()) at ../Python/ceval.c:741
#18 _PyEval_EvalCodeWithName (_co=<optimized out>, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=<optimized out>, kwnames=<optimized out>, kwargs=0x0, kwcount=<optimized out>, kwstep=2, defs=0x0,
    defcount=0, kwdefs=0x0, closure=0x0, name=0x0, qualname=0x0) at ../Python/ceval.c:4298
#19 0x0000000000684327 in PyEval_EvalCodeEx (closure=0x0, kwdefs=0x0, defcount=0, defs=0x0, kwcount=0, kws=0x0, argcount=0, args=0x0, locals=<optimized out>, globals=<optimized out>, _co=<optimized out>) at ../Python/ceval.c:4327
#20 PyEval_EvalCode (co=<optimized out>, globals=<optimized out>, locals=<optimized out>) at ../Python/ceval.c:718
#21 0x0000000000673a41 in run_eval_code_obj (co=0x7f76d6543f50,
    globals={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>},
    locals={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>}) at ../Python/pythonrun.c:1166
#22 0x0000000000673abb in run_mod (mod=<optimized out>, filename=<optimized out>,
    globals={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>},
    locals={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>}, flags=<optimized out>, arena=<optimized out>) at ../Python/pythonrun.c:1188
#23 0x0000000000673b61 in pyrun_file (fp=fp@entry=0xb2d460, filename=filename@entry='a.py', start=start@entry=257,
    globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>},
    locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <SourceFileLoader(name='__main__', path='a.py') at remote 0x7f76d65959a0>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7f76d66120e0>, '__file__': 'a.py', '__cached__': None, 'np': <module at remote 0x7f76d64a84a0>, 'o3d': <module at remote 0x7f76d64a8bd0>, 'pygicp': <module at remote 0x7f765e0681d0>, 'target': <numpy.ndarray at remote 0x7f76d2cec210>, 'gicp': <pygicp.FastGICP at remote 0x7f765e200670>}, closeit=closeit@entry=1, flags=0x7fffe74d34c8) at ../Python/pythonrun.c:1085
#24 0x00000000006747e7 in pyrun_simple_file (flags=0x7fffe74d34c8, closeit=1, filename='a.py', fp=0xb2d460) at ../Python/pythonrun.c:439
#25 PyRun_SimpleFileExFlags (fp=0xb2d460, filename=<optimized out>, closeit=1, flags=0x7fffe74d34c8) at ../Python/pythonrun.c:472
#26 0x00000000006b4072 in pymain_run_file (cf=0x7fffe74d34c8, config=0xb2de00) at ../Modules/main.c:385
#27 pymain_run_python (exitcode=0x7fffe74d34c0) at ../Modules/main.c:610
#28 Py_RunMain () at ../Modules/main.c:689
#29 0x00000000006b43fd in Py_BytesMain (argc=<optimized out>, argv=<optimized out>) at ../Modules/main.c:743
#30 0x00007f76d68a5083 in __libc_start_main (main=0x4c4510 <main>, argc=2, argv=0x7fffe74d36a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffe74d3698) at ../csu/libc-start.c:308
#31 0x00000000005da67e in _start () at ../Objects/abstract.c:1293
```